### PR TITLE
add kubernetes practice

### DIFF
--- a/kubernetes_practice/resources/Dockerfile
+++ b/kubernetes_practice/resources/Dockerfile
@@ -2,10 +2,28 @@ ARG VERSION=xenial
 FROM registry.docker-cn.com/library/ubuntu:$VERSION
 RUN apt update
 RUN apt install -y python3
-RUN mkdir /scripts
-COPY server.py /scripts
-RUN apt install -y git
-RUN apt install -y vim
+#RUN apt install -y git
+#RUN apt install -y vim
 RUN apt install -y curl
-RUN /usr/local/bin/python3 /scripts/server.py > /dev/null 2>&1 &
-RUN /usr/bin/curl localhost:8088
+#RUN apt install -y screen
+COPY server.py /root/
+COPY start-server.sh /root/
+RUN chmod 755 /root/start-server.sh
+#ENTRYPOINT ["/bin/sh", "/root/start-server.sh"]
+
+
+#test1:
+# > docker run -i -t -d --name server-test -p 127.0.0.1:8088:8088 server:test1
+# > docker exec server-test /root/start-server.sh
+# > docker exec server-test curl localhost:8088
+# > "hello"
+# > curl localhost:8088
+# > curl: (52) Empty reply from server
+
+
+#test2
+# > docker run -i -t -d --name server-test -P server:test1 /root/start-server.sh
+# > docker ps
+# The container server-test is not start
+
+

--- a/kubernetes_practice/resources/Dockerfile
+++ b/kubernetes_practice/resources/Dockerfile
@@ -1,6 +1,11 @@
 ARG VERSION=xenial
-FROM ubuntu:$VERSION
+FROM registry.docker-cn.com/library/ubuntu:$VERSION
 RUN apt update
-RUN apt -y install python3
+RUN apt install -y python3
 RUN mkdir /scripts
 COPY server.py /scripts
+RUN apt install -y git
+RUN apt install -y vim
+RUN apt install -y curl
+RUN /usr/local/bin/python3 /scripts/server.py > /dev/null 2>&1 &
+RUN /usr/bin/curl localhost:8088

--- a/kubernetes_practice/resources/Dockerfile
+++ b/kubernetes_practice/resources/Dockerfile
@@ -1,5 +1,6 @@
-ARG VERSION=latest
+ARG VERSION=xenial
 FROM ubuntu:$VERSION
 RUN apt update
 RUN apt -y install python3
-COPY server.py /
+RUN mkdir /scripts
+COPY server.py /scripts

--- a/kubernetes_practice/resources/Dockerfile
+++ b/kubernetes_practice/resources/Dockerfile
@@ -1,0 +1,5 @@
+ARG VERSION=latest
+FROM ubuntu:$VERSION
+RUN apt update
+RUN apt -y install python3
+COPY server.py /

--- a/kubernetes_practice/resources/server.py
+++ b/kubernetes_practice/resources/server.py
@@ -18,7 +18,14 @@ class Request_handler(BaseHTTPRequestHandler):
         self._set_headers()
 
 
-def run(server_class=HTTPServer, handler_class=Request_handler, port=8088):
+def run(server_class=HTTPServer, *, handler_class=Request_handler, port=8088):
+    """
+    运行server
+    :param server_class:
+    :param handler_class:
+    :param port:
+    :return:
+    """
     server_address = ('localhost', port)
     httpd = server_class(server_address, handler_class)
     print('Starting httpd...')

--- a/kubernetes_practice/resources/server.py
+++ b/kubernetes_practice/resources/server.py
@@ -1,0 +1,34 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+"""
+This is a sample http server
+"""
+
+class Request_handler(BaseHTTPRequestHandler):
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_GET(self):
+        self._set_headers()
+        self.wfile.write(bytes("<p>hello</p>", "utf-8"))
+
+    def do_HEAD(self):
+        self._set_headers()
+
+
+def run(server_class=HTTPServer, handler_class=Request_handler, port=8088):
+    server_address = ('localhost', port)
+    httpd = server_class(server_address, handler_class)
+    print('Starting httpd...')
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    from sys import argv
+
+    if len(argv) == 2:
+        run(port=int(argv[1]))
+    else:
+        run()

--- a/kubernetes_practice/resources/server.py
+++ b/kubernetes_practice/resources/server.py
@@ -1,24 +1,28 @@
-from http.server import BaseHTTPRequestHandler, HTTPServer
+import http.server as server
+import logging
+import sys
 
 """
 This is a sample http server
 """
+class RequestHandler(server.BaseHTTPRequestHandler):
+    logging.basicConfig(level = logging.INFO)
+    logger = logging.getLogger("HttpServer")
 
-class Request_handler(BaseHTTPRequestHandler):
     def _set_headers(self):
         self.send_response(200)
         self.send_header('Content-type', 'text/html')
         self.end_headers()
 
-    def do_GET(self):
+    def do_get(self):
         self._set_headers()
         self.wfile.write(bytes("<p>hello</p>", "utf-8"))
 
-    def do_HEAD(self):
+    def do_head(self):
         self._set_headers()
 
 
-def run(server_class=HTTPServer, *, handler_class=Request_handler, port=8088):
+def run(server_class=server.HTTPServer, *, handler_class=RequestHandler, port=8088):
     """
     运行server
     :param server_class:
@@ -26,16 +30,17 @@ def run(server_class=HTTPServer, *, handler_class=Request_handler, port=8088):
     :param port:
     :return:
     """
+    RequestHandler.logger.setLevel(logging.INFO)
     server_address = ('localhost', port)
     httpd = server_class(server_address, handler_class)
-    print('Starting httpd...')
+
+    RequestHandler.logger.info("starting httpd")
+
     httpd.serve_forever()
 
 
 if __name__ == "__main__":
-    from sys import argv
-
-    if len(argv) == 2:
-        run(port=int(argv[1]))
+    if len(sys.argv) == 2:
+        run(port=int(sys.argv[1]))
     else:
         run()

--- a/kubernetes_practice/resources/server.py
+++ b/kubernetes_practice/resources/server.py
@@ -14,11 +14,11 @@ class RequestHandler(server.BaseHTTPRequestHandler):
         self.send_header('Content-type', 'text/html')
         self.end_headers()
 
-    def do_get(self):
+    def do_GET(self):
         self._set_headers()
         self.wfile.write(bytes("<p>hello</p>", "utf-8"))
 
-    def do_head(self):
+    def do_HEAD(self):
         self._set_headers()
 
 

--- a/kubernetes_practice/resources/setup.sh
+++ b/kubernetes_practice/resources/setup.sh
@@ -1,8 +1,9 @@
+#!/usr/bin/env bash
 # pull ubuntu image
 docker pull ubuntu
 
 # use Dockerfile to build an docker image
-docker build Dockerfile
+docker build -t k8s-docker Dockerfile
 
 # download minikube
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64

--- a/kubernetes_practice/resources/setup.sh
+++ b/kubernetes_practice/resources/setup.sh
@@ -1,0 +1,29 @@
+# pull ubuntu image
+docker pull ubuntu
+
+# use Dockerfile to build an docker image
+docker build Dockerfile
+
+# download minikube
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+
+# change the mod of minikube
+chmod +x minikube
+
+# move minikube to /use/local/bin so that we can use command 'minikube' directly
+sudo mv minikube /usr/local/bin/
+
+# start minikube
+minikube start
+
+# create deployment named logi
+kubectl run -it --image=palanqu/docker_learning --port=8088 logi-test
+
+# check the deployment
+kubectl get deploy
+
+# set the environment variable
+export POD_NAME=$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+
+# start the script
+kubectl exec $POD_NAME -- nohup ./start.sh > /dev/null 2>&1 &

--- a/kubernetes_practice/resources/start-server.sh
+++ b/kubernetes_practice/resources/start-server.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python3 /root/server.py > /dev/null 2>&1 &


### PR DESCRIPTION
Dockerfile：构建docker
server.py：python http server，用于构建docker
setup.sh：所有操作记录

问题：kubernetes几乎都是按照官网教程做的，但是教程中当我们
kubectl run kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1 --port=8080
kubectl proxy
curl http://localhost:8001/api/v1/proxy/namespaces/default/pods/$POD_NAME/
是有反馈的
我为了达到和他一样的效果也构建了一个http server，但是我curl localhost:8088就得到下面的结果（我的pods是8088端口）
Error: 'dial tcp 172.17.0.3:8088: getsockopt: connection refused
所以我在教程中就使用kubectl describe pods查看了pod的ip，然后ping了这个ip，发现是ping的通的，但是我同样在我的机器上是ping不同的，所以我的问题就是我的网络配置哪里出错了，为什么完全一样的步骤会出现不同的结果，难道是image的不同导致的吗